### PR TITLE
Use formatter from options

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,5 +78,5 @@ function getFormat(syntax, options) {
 		format = syntaxFormat[format];
 	}
 
-	return Object.assign({}, format, options && options.format);
+	return Object.assign({}, format, options && options.stylesheet);
 }

--- a/test/css.js
+++ b/test/css.js
@@ -61,4 +61,14 @@ describe('CSS Output', () => {
 		assert.equal(expand('@kf'), '@keyframes identifier {\n\t\n}');
 		assert.equal(expand('@kf', null, opt), '@keyframes ${2:identifier} {\n\t${3}\n}');
 	});
+
+	it('format', () => {
+		const opt = {
+			stylesheet: {
+				"between": ":: ",
+				"after": ";;"
+			}
+		};
+		assert.equal(expand('p', null, "css", opt), 'padding:: ;;');
+	})
 });


### PR DESCRIPTION
Currently, the only way the formatter options from the `expand-abbreviation` gets used by the stylesheet-formatter is if the `options` passed to the `expand` call is as below
```
format: {
    format: {
          "between": ":",
          "after": ";"
    }
}
```

This is because the `format` object from the `options` is passed to the formatter here: https://github.com/emmetio/expand-abbreviation/blob/master/lib/css.js#L21

And the stylesheet itself again looks for the `format` property here: https://github.com/emmetio/stylesheet-formatters/blob/master/index.js#L81

Ideally, the `options.format` passed to `expand` call should include the formatter name.
I suggest the `options` being passed to `expand` to look like the below


```json
{
    "syntax": "css",
    "format": {
        "stylesheet": {
             "between": ":",
             "after": ";"
         }
    }
}
```

This will fix https://github.com/emmetio/expand-abbreviation/issues/8 and allow the VS Code Emmet extension to start supporting customization of the `between` and the `after` formatting options

cc @sergeche