### PR TITLE
Do not append after if it already exists in node text

### DIFF
--- a/format/css.js
+++ b/format/css.js
@@ -35,7 +35,7 @@ export default function css(tree, profile, options) {
 		outNode.afterOpen = options.format.between;
 		outNode.text = outNode.renderFields(value || null);
 
-		if (outNode.open && (!outNode.text || !outNode.text.endsWith(options.format.after))) {
+		if (outNode.open && (!outNode.text || !outNode.text.endsWith(';'))) {
 			outNode.afterText = options.format.after;
 		}
 

--- a/format/css.js
+++ b/format/css.js
@@ -35,7 +35,7 @@ export default function css(tree, profile, options) {
 		outNode.afterOpen = options.format.between;
 		outNode.text = outNode.renderFields(value || null);
 
-		if (outNode.open) {
+		if (outNode.open && (!outNode.text || !outNode.text.endsWith(options.format.after))) {
 			outNode.afterText = options.format.after;
 		}
 

--- a/test/css.js
+++ b/test/css.js
@@ -25,7 +25,8 @@ registry.add({
     "bd": "border:${1:1px} ${2:solid} ${3:#000}",
     "bds": "border-style:hidden|dotted|dashed|solid|double|dot-dash|dot-dot-dash|wave|groove|ridge|inset|outset",
 	"lg": "background-image:linear-gradient(${1})",
-	"trf": "transform:scale(${1:x-coord}, ${2:y})"
+	"trf": "transform:scale(${1:x-coord}, ${2:y})",
+	"mten": "margin: 10px;"
 });
 
 function expand(abbr, profile, syntax, options) {
@@ -70,5 +71,9 @@ describe('CSS Output', () => {
 			}
 		};
 		assert.equal(expand('p', null, "css", opt), 'padding:: ;;');
+	});
+
+	it('should not add after if the after is already part of the snippet', () => {
+		assert.equal(expand('mten'), 'margin: 10px;');
 	})
 });


### PR DESCRIPTION
If there is a snippet ending with `;`, the stylesheet-formatter ends up adding another `;` in the end regardless.

Emmet 2.0 can be forgiving of such `;` like the old emmet.

cc @sergeche @user3323